### PR TITLE
[Feat/#18] 추가 임시달력

### DIFF
--- a/dnf_cal/lib/screens/MainPage.dart
+++ b/dnf_cal/lib/screens/MainPage.dart
@@ -1,4 +1,6 @@
+import 'package:dnf_cal/models/CustomColor.dart';
 import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
 
 class MainPage extends StatefulWidget {
   const MainPage({Key? key}) : super(key: key);
@@ -10,25 +12,28 @@ class MainPage extends StatefulWidget {
 class _MainPageState extends State<MainPage> {
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 12, right: 12, top: 44, bottom: 40),
-      child: Container(
-        color: Colors.transparent,
-        child: Column(
-          children: [
-            const SizedBox(
-              height: 98,
-            ),
-            AdventureInfo(),
-            const SizedBox(
-              height: 56,
-            ),
-            CalendarSpace(),
-            const SizedBox(
-              height: 76,
-            ),
-            RefreshButton(),
-          ],
+    return Container(
+      color: Colors.grey[400],
+      child: Padding(
+        padding:
+            const EdgeInsets.only(left: 12, right: 12, top: 54, bottom: 40),
+        child: Container(
+          color: Colors.grey,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.max,
+            children: [
+              SizedBox(
+                height: 44,
+              ),
+              AdventureInfo(),
+              SizedBox(
+                height: 56,
+              ),
+              CalendarSpace(),
+              RefreshButton(),
+            ],
+          ),
         ),
       ),
     );
@@ -96,17 +101,149 @@ class AdventureInfo extends StatelessWidget {
   }
 }
 
-// 달력 위젯 공간, 현재는 달력이 구현되어 있지 않고 공간만 할당, 남은 공간을 모두 사용함
-class CalendarSpace extends StatelessWidget {
+class CalendarSpace extends StatefulWidget {
   const CalendarSpace({Key? key}) : super(key: key);
+
+  @override
+  State<CalendarSpace> createState() => _CalendarSpaceState();
+}
+
+class _CalendarSpaceState extends State<CalendarSpace> {
+  final Map<DateTime, List> _itemLevel = {
+    DateTime.utc(2024, 1, 1): ['10'],
+    DateTime.utc(2024, 1, 3): ['120'],
+    DateTime.utc(2024, 1, 5): ['356'],
+    DateTime.utc(2024, 1, 8): ['362'],
+    DateTime.utc(2024, 1, 15): ['480'],
+  };
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: Container(
-        color: Colors.blue,
-        child: Center(
-          child: Text('달력'),
+      child: Center(
+        child: TableCalendar(
+          firstDay: DateTime.utc(2021, 1, 1),
+          lastDay: DateTime.utc(2024, 12, 31),
+          focusedDay: DateTime.now(),
+          headerStyle: HeaderStyle(
+            decoration: BoxDecoration(
+              color: Color(0xff0f172f),
+            ),
+            titleCentered: true,
+            formatButtonVisible: false,
+            leftChevronIcon: Icon(
+              Icons.chevron_left,
+              color: Colors.white,
+            ),
+            rightChevronIcon: Icon(
+              Icons.chevron_right,
+              color: Colors.white,
+            ),
+            titleTextStyle: TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontFamily: 'DNFForgedBlade',
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          daysOfWeekStyle: DaysOfWeekStyle(
+            decoration: BoxDecoration(
+              color: Color(0xff0f172f),
+            ),
+            weekdayStyle: TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontFamily: 'DNFForgedBlade',
+              fontWeight: FontWeight.w500,
+            ),
+            weekendStyle: TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontFamily: 'DNFForgedBlade',
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          calendarStyle: CalendarStyle(
+            rowDecoration: BoxDecoration(
+              color: Color(0xff0f172f),
+            ),
+            weekendTextStyle: TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontFamily: 'DNFForgedBlade',
+              fontWeight: FontWeight.w500,
+            ),
+            defaultTextStyle: TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontFamily: 'DNFForgedBlade',
+              fontWeight: FontWeight.w500,
+            ),
+            selectedTextStyle: TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontFamily: 'DNFForgedBlade',
+              fontWeight: FontWeight.w500,
+            ),
+            todayTextStyle: TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontFamily: 'DNFForgedBlade',
+              fontWeight: FontWeight.w500,
+            ),
+            outsideTextStyle: TextStyle(
+              color: Color(0xff64748B),
+              fontSize: 12,
+              fontFamily: 'DNFForgedBlade',
+              fontWeight: FontWeight.w500,
+            ),
+            todayDecoration: BoxDecoration(
+              color: Color(0xff0f172f),
+              shape: BoxShape.circle,
+            ),
+          ),
+          eventLoader: (day) => _itemLevel[day] ?? [],
+          calendarBuilders: CalendarBuilders(
+            markerBuilder: (context, day, events) {
+              if (events.isNotEmpty) {
+                int levelValue = int.parse(events[0].toString()) ~/ 120;
+
+                Color levelColor;
+                switch (levelValue) {
+                  case 0:
+                    levelColor = CustomColor.common();
+                    break;
+                  case 1:
+                    levelColor = CustomColor.uncommon();
+                    break;
+                  case 2:
+                    levelColor = CustomColor.rare();
+                    break;
+                  case 3:
+                    levelColor = CustomColor.unique();
+                    break;
+                  case 4:
+                    levelColor = CustomColor.epic();
+                    break;
+                  default:
+                    levelColor = Colors.red;
+                }
+                return Positioned(
+                  bottom: 1,
+                  child: Text(
+                    '${events[0]}',
+                    style: TextStyle(
+                      color: levelColor,
+                      fontSize: 12,
+                      fontFamily: 'DNFForgedBlade',
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                );
+              }
+              return Container();
+            },
+          ),
         ),
       ),
     );

--- a/dnf_cal/pubspec.yaml
+++ b/dnf_cal/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  table_calendar: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #18 

## ✅ What Did You Do
- [x] 임시 달력 구현

***

## 🎸 ETC
달력 색은 피그마 원본과 일단은 동일함
폰트는 전부 DNF폰트로 맞춤
달력길이로 인해 달력공간의 padding 수정