### PR TITLE
[Feat/#50] 달력 페이지 DB 연동

### DIFF
--- a/dnf_cal/lib/main.dart
+++ b/dnf_cal/lib/main.dart
@@ -15,12 +15,13 @@ import 'package:flutter/material.dart';
 import 'models/SearchModel.dart';
 import 'package:realm/realm.dart';
 import 'realm/Character.dart';
+import 'realm/Calendar.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: ".env"); // 추가
   // realm 초기화
-  var config = Configuration.local([Character.schema]);
+  var config = Configuration.local([Character.schema, Calendar.schema]);
   var realm = Realm(config);
   runApp(MultiProvider(
     providers: [

--- a/dnf_cal/lib/main.dart
+++ b/dnf_cal/lib/main.dart
@@ -14,7 +14,7 @@ import 'package:dnf_cal/widgets/global/BottomNavigationWidget.dart';
 import 'package:flutter/material.dart';
 import 'models/SearchModel.dart';
 import 'package:realm/realm.dart';
-import 'realm/Chracter.dart';
+import 'realm/Character.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/dnf_cal/lib/models/RegisterCharacterModel.dart
+++ b/dnf_cal/lib/models/RegisterCharacterModel.dart
@@ -25,8 +25,9 @@ class RegisterCharacterModel with ChangeNotifier {
   }
 
   // realm에 저장되있는 chracter 리스트를 가져와 _characterList에 저장한다.
-  loadCharacterList() {
+  Future<void> loadCharacterList() async {
     _characterList = _realm.all<Character>().toList();
+    notifyListeners();
   }
 
   // realm에 저장되있는 chracter 중 id가 일치하는 chracter를 삭제한다.

--- a/dnf_cal/lib/models/RegisterCharacterModel.dart
+++ b/dnf_cal/lib/models/RegisterCharacterModel.dart
@@ -41,6 +41,7 @@ class RegisterCharacterModel with ChangeNotifier {
     if (characterList.isEmpty) {
       _isEmpty = true;
     }
+    _isEditing = false;
     notifyListeners();
   }
 

--- a/dnf_cal/lib/models/RegisterCharacterModel.dart
+++ b/dnf_cal/lib/models/RegisterCharacterModel.dart
@@ -5,22 +5,92 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:realm/realm.dart';
 import 'package:dnf_cal/realm/Character.dart';
+import 'package:dnf_cal/realm/Calendar.dart';
 
 class RegisterCharacterModel with ChangeNotifier {
   bool _isEditing = false;
   bool _isEmpty = false;
   final Realm _realm;
+  String _lastUpdate = "";
   List<Character> _characterList = [];
+  Map<DateTime, List> _itemLevel = {};
 
   RegisterCharacterModel()
-      : _realm = Realm(Configuration.local([Character.schema]));
+      : _realm =
+            Realm(Configuration.local([Character.schema, Calendar.schema]));
 
   bool get isEditing => _isEditing;
   bool get isEmpty => _isEmpty;
   List<Character> get characterList => _characterList;
+  Map<DateTime, List> get itemLevel => _itemLevel;
+  String get lastUpdate => _lastUpdate;
 
   toggleEditing() {
     _isEditing = !_isEditing;
+    notifyListeners();
+  }
+
+  Future<void> loadItemLevel() async {
+    // itemLevel을 저장하는 과정중에 가장 마지막 날짜를 저장한다.
+    _itemLevel = _realm.all<Calendar>().toList().fold({}, (map, calendar) {
+      map[DateTime.utc(
+          calendar.year ?? 0, calendar.month ?? 0, calendar.day ?? 0)] = [
+        calendar.itemLevel
+      ];
+      return map;
+    });
+    // 마지막 날짜를 저장한다.
+    _lastUpdate =
+        _realm.all<Calendar>().toList().fold("", (lastUpdate, calendar) {
+      return "${calendar.year}-${calendar.month}-${calendar.day}-${calendar.hour}:${calendar.miniute}";
+    });
+    notifyListeners();
+  }
+
+  // realm에 저장되있는 chracter 리스트의 characterId를 이용해 API를 호출하여 정보를 갱신한다.
+  Future<void> updateCharacterList() async {
+    for (Character character in _characterList) {
+      List<SearchCharacterModel> info = await APIModel.fetchDataFromApi(
+        character.characterName ?? "",
+        character.serverId ?? "",
+      );
+      await APIModel.fetchCharacterFromApi(info[0]);
+    }
+    _characterList = _realm.all<Character>().toList();
+    // 현재 year, month, day, hour, miniute를 가져온다.
+    DateTime now = DateTime.now();
+    // CharacterList를 순회하며 총합템레벨의 평균을 구한다.
+    int totalItemLevel = _characterList.fold(0, (sum, character) {
+      return sum + (character.totalItemLevel ?? 0);
+    });
+    int averageItemLevel = totalItemLevel ~/ _characterList.length;
+    // 위에서 구한 정보를 바탕으로 Calendar에 저장한다.
+    // 오늘 날짜(년, 월, 일)에 이미 저장된 정보가 있는지 검사
+    var calendar = _realm.find<Calendar>(
+        "${now.year}-${now.month}-${now.day}-${now.hour}:${now.minute}");
+    // 있다면 갱신, 없다면 추가
+    if (calendar != null) {
+      _realm.write(() {
+        calendar.itemLevel = averageItemLevel;
+        calendar.characterList.clear();
+        calendar.characterList.addAll(_characterList);
+      });
+    } else {
+      _realm.write(() {
+        _realm.add(Calendar(
+          "${now.year}-${now.month}-${now.day}-${now.hour}:${now.minute}",
+          year: now.year,
+          month: now.month,
+          day: now.day,
+          hour: now.hour,
+          miniute: now.minute,
+          itemLevel: averageItemLevel,
+          characterList: _characterList,
+        ));
+      });
+    }
+    // Calendar에 저장된 정보를 가져와 _itemLevel에 저장한다.
+    loadItemLevel();
     notifyListeners();
   }
 
@@ -51,6 +121,7 @@ class RegisterCharacterModel with ChangeNotifier {
     // 모험단 이름을 찾아올 때 비어있는 index를 참조하지 않도록 1초 대기
     await Future.delayed(Duration(seconds: 1));
     _characterList = _realm.all<Character>().toList();
+    notifyListeners();
     if (characterList.isNotEmpty) {
       _isEmpty = false;
     }

--- a/dnf_cal/lib/models/RegisterCharacterModel.dart
+++ b/dnf_cal/lib/models/RegisterCharacterModel.dart
@@ -46,8 +46,12 @@ class RegisterCharacterModel with ChangeNotifier {
 
   Future<void> addCharacter(SearchCharacterModel info) async {
     await APIModel.fetchCharacterFromApi(info);
+    // 모험단 이름을 찾아올 때 비어있는 index를 참조하지 않도록 1초 대기
+    await Future.delayed(Duration(seconds: 1));
     _characterList = _realm.all<Character>().toList();
-    _isEmpty = false;
+    if (characterList.isNotEmpty) {
+      _isEmpty = false;
+    }
     notifyListeners();
   }
 }

--- a/dnf_cal/lib/models/RegisterCharacterModel.dart
+++ b/dnf_cal/lib/models/RegisterCharacterModel.dart
@@ -4,7 +4,7 @@ import 'package:dnf_cal/widgets/RegisterCharacterPage/CharacterProfile.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:realm/realm.dart';
-import 'package:dnf_cal/realm/Chracter.dart';
+import 'package:dnf_cal/realm/Character.dart';
 
 class RegisterCharacterModel with ChangeNotifier {
   bool _isEditing = false;

--- a/dnf_cal/lib/realm/Calendar.dart
+++ b/dnf_cal/lib/realm/Calendar.dart
@@ -1,0 +1,18 @@
+import 'package:realm/realm.dart';
+import 'package:dnf_cal/realm/Character.dart';
+
+part 'Calendar.g.dart';
+
+@RealmModel()
+class _Calendar {
+  @PrimaryKey()
+  late final String date;
+
+  int? year;
+  int? month;
+  int? day;
+  int? hour;
+  int? miniute;
+  int? itemLevel;
+  late List<$Character> characterList;
+}

--- a/dnf_cal/lib/realm/Calendar.g.dart
+++ b/dnf_cal/lib/realm/Calendar.g.dart
@@ -1,0 +1,101 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'Calendar.dart';
+
+// **************************************************************************
+// RealmObjectGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+class Calendar extends _Calendar
+    with RealmEntity, RealmObjectBase, RealmObject {
+  Calendar(
+    String date, {
+    int? year,
+    int? month,
+    int? day,
+    int? hour,
+    int? miniute,
+    int? itemLevel,
+    Iterable<Character> characterList = const [],
+  }) {
+    RealmObjectBase.set(this, 'date', date);
+    RealmObjectBase.set(this, 'year', year);
+    RealmObjectBase.set(this, 'month', month);
+    RealmObjectBase.set(this, 'day', day);
+    RealmObjectBase.set(this, 'hour', hour);
+    RealmObjectBase.set(this, 'miniute', miniute);
+    RealmObjectBase.set(this, 'itemLevel', itemLevel);
+    RealmObjectBase.set<RealmList<Character>>(
+        this, 'characterList', RealmList<Character>(characterList));
+  }
+
+  Calendar._();
+
+  @override
+  String get date => RealmObjectBase.get<String>(this, 'date') as String;
+  @override
+  set date(String value) => throw RealmUnsupportedSetError();
+
+  @override
+  int? get year => RealmObjectBase.get<int>(this, 'year') as int?;
+  @override
+  set year(int? value) => RealmObjectBase.set(this, 'year', value);
+
+  @override
+  int? get month => RealmObjectBase.get<int>(this, 'month') as int?;
+  @override
+  set month(int? value) => RealmObjectBase.set(this, 'month', value);
+
+  @override
+  int? get day => RealmObjectBase.get<int>(this, 'day') as int?;
+  @override
+  set day(int? value) => RealmObjectBase.set(this, 'day', value);
+
+  @override
+  int? get hour => RealmObjectBase.get<int>(this, 'hour') as int?;
+  @override
+  set hour(int? value) => RealmObjectBase.set(this, 'hour', value);
+
+  @override
+  int? get miniute => RealmObjectBase.get<int>(this, 'miniute') as int?;
+  @override
+  set miniute(int? value) => RealmObjectBase.set(this, 'miniute', value);
+
+  @override
+  int? get itemLevel => RealmObjectBase.get<int>(this, 'itemLevel') as int?;
+  @override
+  set itemLevel(int? value) => RealmObjectBase.set(this, 'itemLevel', value);
+
+  @override
+  RealmList<Character> get characterList =>
+      RealmObjectBase.get<Character>(this, 'characterList')
+          as RealmList<Character>;
+  @override
+  set characterList(covariant RealmList<Character> value) =>
+      throw RealmUnsupportedSetError();
+
+  @override
+  Stream<RealmObjectChanges<Calendar>> get changes =>
+      RealmObjectBase.getChanges<Calendar>(this);
+
+  @override
+  Calendar freeze() => RealmObjectBase.freezeObject<Calendar>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Calendar._);
+    return const SchemaObject(ObjectType.realmObject, Calendar, 'Calendar', [
+      SchemaProperty('date', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('year', RealmPropertyType.int, optional: true),
+      SchemaProperty('month', RealmPropertyType.int, optional: true),
+      SchemaProperty('day', RealmPropertyType.int, optional: true),
+      SchemaProperty('hour', RealmPropertyType.int, optional: true),
+      SchemaProperty('miniute', RealmPropertyType.int, optional: true),
+      SchemaProperty('itemLevel', RealmPropertyType.int, optional: true),
+      SchemaProperty('characterList', RealmPropertyType.object,
+          linkTarget: 'Character', collectionType: RealmCollectionType.list),
+    ]);
+  }
+}

--- a/dnf_cal/lib/realm/Character.dart
+++ b/dnf_cal/lib/realm/Character.dart
@@ -1,6 +1,6 @@
 import 'package:realm/realm.dart';
 
-part 'Chracter.g.dart';
+part 'Character.g.dart';
 
 @RealmModel()
 class _Character {
@@ -18,4 +18,17 @@ class _Character {
   String? adventureName;
   String? guildName;
   int? totalItemLevel;
+}
+
+@RealmModel()
+class _Calendar {
+  @PrimaryKey()
+  late final String date;
+
+  int? year;
+  int? month;
+  int? day;
+  int? hour;
+  int? miniute;
+  int? itemLevel;
 }

--- a/dnf_cal/lib/realm/Character.dart
+++ b/dnf_cal/lib/realm/Character.dart
@@ -3,7 +3,7 @@ import 'package:realm/realm.dart';
 part 'Character.g.dart';
 
 @RealmModel()
-class _Character {
+class $Character {
   @PrimaryKey()
   late final String characterId;
 
@@ -18,17 +18,4 @@ class _Character {
   String? adventureName;
   String? guildName;
   int? totalItemLevel;
-}
-
-@RealmModel()
-class _Calendar {
-  @PrimaryKey()
-  late final String date;
-
-  int? year;
-  int? month;
-  int? day;
-  int? hour;
-  int? miniute;
-  int? itemLevel;
 }

--- a/dnf_cal/lib/realm/Character.g.dart
+++ b/dnf_cal/lib/realm/Character.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'Chracter.dart';
+part of 'Character.dart';
 
 // **************************************************************************
 // RealmObjectGenerator
@@ -136,6 +136,86 @@ class Character extends _Character
       SchemaProperty('adventureName', RealmPropertyType.string, optional: true),
       SchemaProperty('guildName', RealmPropertyType.string, optional: true),
       SchemaProperty('totalItemLevel', RealmPropertyType.int, optional: true),
+    ]);
+  }
+}
+
+class Calendar extends _Calendar
+    with RealmEntity, RealmObjectBase, RealmObject {
+  Calendar(
+    String date, {
+    int? year,
+    int? month,
+    int? day,
+    int? hour,
+    int? miniute,
+    int? itemLevel,
+  }) {
+    RealmObjectBase.set(this, 'date', date);
+    RealmObjectBase.set(this, 'year', year);
+    RealmObjectBase.set(this, 'month', month);
+    RealmObjectBase.set(this, 'day', day);
+    RealmObjectBase.set(this, 'hour', hour);
+    RealmObjectBase.set(this, 'miniute', miniute);
+    RealmObjectBase.set(this, 'itemLevel', itemLevel);
+  }
+
+  Calendar._();
+
+  @override
+  String get date => RealmObjectBase.get<String>(this, 'date') as String;
+  @override
+  set date(String value) => throw RealmUnsupportedSetError();
+
+  @override
+  int? get year => RealmObjectBase.get<int>(this, 'year') as int?;
+  @override
+  set year(int? value) => RealmObjectBase.set(this, 'year', value);
+
+  @override
+  int? get month => RealmObjectBase.get<int>(this, 'month') as int?;
+  @override
+  set month(int? value) => RealmObjectBase.set(this, 'month', value);
+
+  @override
+  int? get day => RealmObjectBase.get<int>(this, 'day') as int?;
+  @override
+  set day(int? value) => RealmObjectBase.set(this, 'day', value);
+
+  @override
+  int? get hour => RealmObjectBase.get<int>(this, 'hour') as int?;
+  @override
+  set hour(int? value) => RealmObjectBase.set(this, 'hour', value);
+
+  @override
+  int? get miniute => RealmObjectBase.get<int>(this, 'miniute') as int?;
+  @override
+  set miniute(int? value) => RealmObjectBase.set(this, 'miniute', value);
+
+  @override
+  int? get itemLevel => RealmObjectBase.get<int>(this, 'itemLevel') as int?;
+  @override
+  set itemLevel(int? value) => RealmObjectBase.set(this, 'itemLevel', value);
+
+  @override
+  Stream<RealmObjectChanges<Calendar>> get changes =>
+      RealmObjectBase.getChanges<Calendar>(this);
+
+  @override
+  Calendar freeze() => RealmObjectBase.freezeObject<Calendar>(this);
+
+  static SchemaObject get schema => _schema ??= _initSchema();
+  static SchemaObject? _schema;
+  static SchemaObject _initSchema() {
+    RealmObjectBase.registerFactory(Calendar._);
+    return const SchemaObject(ObjectType.realmObject, Calendar, 'Calendar', [
+      SchemaProperty('date', RealmPropertyType.string, primaryKey: true),
+      SchemaProperty('year', RealmPropertyType.int, optional: true),
+      SchemaProperty('month', RealmPropertyType.int, optional: true),
+      SchemaProperty('day', RealmPropertyType.int, optional: true),
+      SchemaProperty('hour', RealmPropertyType.int, optional: true),
+      SchemaProperty('miniute', RealmPropertyType.int, optional: true),
+      SchemaProperty('itemLevel', RealmPropertyType.int, optional: true),
     ]);
   }
 }

--- a/dnf_cal/lib/realm/Character.g.dart
+++ b/dnf_cal/lib/realm/Character.g.dart
@@ -7,7 +7,7 @@ part of 'Character.dart';
 // **************************************************************************
 
 // ignore_for_file: type=lint
-class Character extends _Character
+class Character extends $Character
     with RealmEntity, RealmObjectBase, RealmObject {
   Character(
     String characterId, {
@@ -136,86 +136,6 @@ class Character extends _Character
       SchemaProperty('adventureName', RealmPropertyType.string, optional: true),
       SchemaProperty('guildName', RealmPropertyType.string, optional: true),
       SchemaProperty('totalItemLevel', RealmPropertyType.int, optional: true),
-    ]);
-  }
-}
-
-class Calendar extends _Calendar
-    with RealmEntity, RealmObjectBase, RealmObject {
-  Calendar(
-    String date, {
-    int? year,
-    int? month,
-    int? day,
-    int? hour,
-    int? miniute,
-    int? itemLevel,
-  }) {
-    RealmObjectBase.set(this, 'date', date);
-    RealmObjectBase.set(this, 'year', year);
-    RealmObjectBase.set(this, 'month', month);
-    RealmObjectBase.set(this, 'day', day);
-    RealmObjectBase.set(this, 'hour', hour);
-    RealmObjectBase.set(this, 'miniute', miniute);
-    RealmObjectBase.set(this, 'itemLevel', itemLevel);
-  }
-
-  Calendar._();
-
-  @override
-  String get date => RealmObjectBase.get<String>(this, 'date') as String;
-  @override
-  set date(String value) => throw RealmUnsupportedSetError();
-
-  @override
-  int? get year => RealmObjectBase.get<int>(this, 'year') as int?;
-  @override
-  set year(int? value) => RealmObjectBase.set(this, 'year', value);
-
-  @override
-  int? get month => RealmObjectBase.get<int>(this, 'month') as int?;
-  @override
-  set month(int? value) => RealmObjectBase.set(this, 'month', value);
-
-  @override
-  int? get day => RealmObjectBase.get<int>(this, 'day') as int?;
-  @override
-  set day(int? value) => RealmObjectBase.set(this, 'day', value);
-
-  @override
-  int? get hour => RealmObjectBase.get<int>(this, 'hour') as int?;
-  @override
-  set hour(int? value) => RealmObjectBase.set(this, 'hour', value);
-
-  @override
-  int? get miniute => RealmObjectBase.get<int>(this, 'miniute') as int?;
-  @override
-  set miniute(int? value) => RealmObjectBase.set(this, 'miniute', value);
-
-  @override
-  int? get itemLevel => RealmObjectBase.get<int>(this, 'itemLevel') as int?;
-  @override
-  set itemLevel(int? value) => RealmObjectBase.set(this, 'itemLevel', value);
-
-  @override
-  Stream<RealmObjectChanges<Calendar>> get changes =>
-      RealmObjectBase.getChanges<Calendar>(this);
-
-  @override
-  Calendar freeze() => RealmObjectBase.freezeObject<Calendar>(this);
-
-  static SchemaObject get schema => _schema ??= _initSchema();
-  static SchemaObject? _schema;
-  static SchemaObject _initSchema() {
-    RealmObjectBase.registerFactory(Calendar._);
-    return const SchemaObject(ObjectType.realmObject, Calendar, 'Calendar', [
-      SchemaProperty('date', RealmPropertyType.string, primaryKey: true),
-      SchemaProperty('year', RealmPropertyType.int, optional: true),
-      SchemaProperty('month', RealmPropertyType.int, optional: true),
-      SchemaProperty('day', RealmPropertyType.int, optional: true),
-      SchemaProperty('hour', RealmPropertyType.int, optional: true),
-      SchemaProperty('miniute', RealmPropertyType.int, optional: true),
-      SchemaProperty('itemLevel', RealmPropertyType.int, optional: true),
     ]);
   }
 }

--- a/dnf_cal/lib/screens/CharacterSearchPage.dart
+++ b/dnf_cal/lib/screens/CharacterSearchPage.dart
@@ -9,7 +9,7 @@ import '../widgets/CharacterSearch/CharacterSearchTopWidget.dart';
 import '../widgets/CharacterSearch/SearchCharacterCellScroll.dart';
 import '../widgets/CharacterSearch/SearchResultTitleWidget.dart';
 import '../widgets/CharacterSearch/SearchAndFilterWidget.dart';
-import '../realm/Chracter.dart';
+import '../realm/Character.dart';
 
 class CharacterSearchPage extends StatefulWidget {
   const CharacterSearchPage({Key? key}) : super(key: key);

--- a/dnf_cal/lib/screens/MainPage.dart
+++ b/dnf_cal/lib/screens/MainPage.dart
@@ -1,6 +1,8 @@
 import 'package:dnf_cal/widgets/MainPage/AdventureInfo.dart';
 import 'package:dnf_cal/widgets/MainPage/CalendarSpace.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:dnf_cal/models/RegisterCharacterModel.dart';
 
 class MainPage extends StatefulWidget {
   const MainPage({Key? key}) : super(key: key);
@@ -38,5 +40,14 @@ class _MainPageState extends State<MainPage> {
         ),
       ),
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await Provider.of<RegisterCharacterModel>(context, listen: false)
+          .loadCharacterList();
+    });
   }
 }

--- a/dnf_cal/lib/screens/MainPage.dart
+++ b/dnf_cal/lib/screens/MainPage.dart
@@ -48,6 +48,8 @@ class _MainPageState extends State<MainPage> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await Provider.of<RegisterCharacterModel>(context, listen: false)
           .loadCharacterList();
+      await Provider.of<RegisterCharacterModel>(context, listen: false)
+          .loadItemLevel();
     });
   }
 }

--- a/dnf_cal/lib/screens/RegisterCharacterPage.dart
+++ b/dnf_cal/lib/screens/RegisterCharacterPage.dart
@@ -57,11 +57,4 @@ class _RegisterCharactersState extends State<_RegisterCharacters> {
       ),
     );
   }
-
-  @override
-  void initState() {
-    super.initState();
-    Provider.of<RegisterCharacterModel>(context, listen: false)
-        .loadCharacterList();
-  }
 }

--- a/dnf_cal/lib/screens/RegisterCharacterPage.dart
+++ b/dnf_cal/lib/screens/RegisterCharacterPage.dart
@@ -40,8 +40,7 @@ class _RegisterCharacters extends StatefulWidget {
 class _RegisterCharactersState extends State<_RegisterCharacters> {
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<RegisterCharacterModel>(context);
-    final characterList = model.characterList;
+    final characterList = context.watch<RegisterCharacterModel>().characterList;
     return Expanded(
       child: GridView(
         padding: EdgeInsets.only(top: 22, left: 22, right: 22),

--- a/dnf_cal/lib/screens/RegisterCharacterPage.dart
+++ b/dnf_cal/lib/screens/RegisterCharacterPage.dart
@@ -1,6 +1,6 @@
 import 'package:dnf_cal/models/CustomColor.dart';
 import 'package:dnf_cal/models/RegisterCharacterModel.dart';
-import 'package:dnf_cal/realm/Chracter.dart';
+import 'package:dnf_cal/realm/Character.dart';
 import 'package:dnf_cal/widgets/RegisterCharacterPage/CharacterProfile.dart';
 import 'package:dnf_cal/widgets/RegisterCharacterPage/RegisterChracterEditBar.dart';
 import 'package:flutter/material.dart';

--- a/dnf_cal/lib/utils/APIModel.dart
+++ b/dnf_cal/lib/utils/APIModel.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:realm/realm.dart';
-import 'package:dnf_cal/realm/Chracter.dart';
+import 'package:dnf_cal/realm/Character.dart';
 
 import '../models/SearchCharacterModel.dart';
 

--- a/dnf_cal/lib/utils/APIModel.dart
+++ b/dnf_cal/lib/utils/APIModel.dart
@@ -7,6 +7,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:realm/realm.dart';
 import 'package:dnf_cal/realm/Character.dart';
+import 'package:dnf_cal/realm/Calendar.dart';
 
 import '../models/SearchCharacterModel.dart';
 
@@ -43,7 +44,7 @@ class APIModel {
           '$baseUrl/df/servers/${info.serverId}/characters/${info.characterId}/equip/equipment?apikey=$apikey');
       if (response.statusCode == 200) {
         final Map<String, dynamic> jsonResponse = response.data;
-        var config = Configuration.local([Character.schema]);
+        var config = Configuration.local([Character.schema, Calendar.schema]);
         var realm = Realm(config);
 
         // db에 캐릭터가 있는지 확인
@@ -64,6 +65,22 @@ class APIModel {
               calculateTotalItemLevel(jsonResponse) as int;
           realm.write(() {
             realm.add(character as Character);
+          });
+        } else {
+          // 있다면 새로운 정보로 갱신
+          realm.write(() {
+            character?.characterName = info.characterName;
+            character?.serverId = info.serverId;
+            character?.level = info.level;
+            character?.jobId = info.jobId;
+            character?.jobGrowId = info.jobGrowId;
+            character?.jobName = info.jobName;
+            character?.jobGrowName = info.jobGrowName;
+            character?.fame = info.fame ?? 0;
+            character?.adventureName = jsonResponse['adventureName'];
+            character?.guildName = jsonResponse['guildName'];
+            character?.totalItemLevel =
+                calculateTotalItemLevel(jsonResponse) as int;
           });
         }
 

--- a/dnf_cal/lib/widgets/MainPage/AdventureInfo.dart
+++ b/dnf_cal/lib/widgets/MainPage/AdventureInfo.dart
@@ -1,12 +1,31 @@
 import 'package:dnf_cal/models/CustomColor.dart';
 import 'package:dnf_cal/widgets/global/DnfText.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../models/RegisterCharacterModel.dart';
 
 class AdventureInfo extends StatelessWidget {
   const AdventureInfo({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final String adventurerName;
+    final int characterCount;
+    if (context.watch<RegisterCharacterModel>().isEmpty ||
+        context.watch<RegisterCharacterModel>().characterList.isEmpty) {
+      adventurerName = "등록된 캐릭터가 없습니다.";
+      characterCount = 0;
+    } else {
+      adventurerName = context
+              .read<RegisterCharacterModel>()
+              .characterList
+              .first
+              .adventureName ??
+          "등록된 캐릭터가 없습니다.";
+      characterCount =
+          context.read<RegisterCharacterModel>().characterList.length;
+    }
+
     return Container(
       decoration: BoxDecoration(
         border: Border.fromBorderSide(
@@ -42,16 +61,15 @@ class AdventureInfo extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Align(
-                  alignment: Alignment.centerLeft,
-                  child: DnfText('모험단 이름'),
-                ),
+                    alignment: Alignment.centerLeft,
+                    child: DnfText(adventurerName)),
                 SizedBox(
                   height: 12,
                 ),
                 Align(
                   alignment: Alignment.centerLeft,
                   child: DnfText(
-                    '등록된 캐릭터: 1개',
+                    '등록된 캐릭터: ${characterCount}개',
                     color: CustomColor.chronicle(),
                     fontSize: 10,
                   ),
@@ -62,7 +80,7 @@ class AdventureInfo extends StatelessWidget {
                 Align(
                   alignment: Alignment.centerLeft,
                   child: DnfText(
-                    '최근 갱신 날짜: 2024-01-10-12:12',
+                    '최근 갱신 날짜: -',
                     color: CustomColor.legendary(),
                     fontSize: 10,
                   ),

--- a/dnf_cal/lib/widgets/MainPage/AdventureInfo.dart
+++ b/dnf_cal/lib/widgets/MainPage/AdventureInfo.dart
@@ -47,10 +47,18 @@ class AdventureInfo extends StatelessWidget {
               height: 97,
               color: Colors.transparent,
               child: Center(
-                child: Icon(
-                  Icons.refresh,
-                  size: 37,
-                  color: CustomColor.darkGray(),
+                child: IconButton(
+                  onPressed: () {
+                    context
+                        .read<RegisterCharacterModel>()
+                        .updateCharacterList();
+                    context.read<RegisterCharacterModel>().loadItemLevel();
+                  },
+                  icon: Icon(
+                    Icons.refresh,
+                    size: 37,
+                    color: CustomColor.darkGray(),
+                  ),
                 ),
               ),
             ),
@@ -80,7 +88,7 @@ class AdventureInfo extends StatelessWidget {
                 Align(
                   alignment: Alignment.centerLeft,
                   child: DnfText(
-                    '최근 갱신 날짜: -',
+                    '최근 갱신 날짜: ${context.watch<RegisterCharacterModel>().lastUpdate}',
                     color: CustomColor.legendary(),
                     fontSize: 10,
                   ),

--- a/dnf_cal/lib/widgets/MainPage/CalendarSpace.dart
+++ b/dnf_cal/lib/widgets/MainPage/CalendarSpace.dart
@@ -9,6 +9,7 @@ import 'package:dnf_cal/widgets/global/DnfText.dart';
 import 'package:provider/provider.dart';
 import 'package:realm/realm.dart';
 import 'package:dnf_cal/realm/Character.dart';
+import 'package:dnf_cal/models/RegisterCharacterModel.dart';
 
 class CalendarSpace extends StatefulWidget {
   const CalendarSpace({Key? key}) : super(key: key);
@@ -18,18 +19,16 @@ class CalendarSpace extends StatefulWidget {
 }
 
 class _CalendarSpaceState extends State<CalendarSpace> {
-  // Calendar DB에서 데이터를 가져와야 함
-  final Map<DateTime, List> _itemLevel = {
-    DateTime.utc(2024, 1, 1): ['1'],
-  };
-
+  // Calendar DB의 데이터를 Map으로 저장
   @override
   Widget build(BuildContext context) {
+    final Map<DateTime, List> _itemLevel =
+        context.watch<RegisterCharacterModel>().itemLevel;
     return Expanded(
       child: Center(
         child: TableCalendar(
           firstDay: DateTime.utc(2021, 1, 1),
-          lastDay: DateTime.utc(2024, 12, 31),
+          lastDay: DateTime.utc(2025, 12, 31),
           focusedDay: DateTime.now(),
           headerStyle: buildHeaderStyle(),
           daysOfWeekStyle: buildDaysOfWeekStyle(),

--- a/dnf_cal/lib/widgets/MainPage/CalendarSpace.dart
+++ b/dnf_cal/lib/widgets/MainPage/CalendarSpace.dart
@@ -6,6 +6,9 @@ import 'package:dnf_cal/widgets/MainPage/CalendarStyle.dart/BuildHeaderStyle.dar
 import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:dnf_cal/widgets/global/DnfText.dart';
+import 'package:provider/provider.dart';
+import 'package:realm/realm.dart';
+import 'package:dnf_cal/realm/Character.dart';
 
 class CalendarSpace extends StatefulWidget {
   const CalendarSpace({Key? key}) : super(key: key);
@@ -15,12 +18,9 @@ class CalendarSpace extends StatefulWidget {
 }
 
 class _CalendarSpaceState extends State<CalendarSpace> {
+  // Calendar DB에서 데이터를 가져와야 함
   final Map<DateTime, List> _itemLevel = {
-    DateTime.utc(2024, 1, 1): ['10'],
-    DateTime.utc(2024, 1, 3): ['120'],
-    DateTime.utc(2024, 1, 5): ['356'],
-    DateTime.utc(2024, 1, 8): ['362'],
-    DateTime.utc(2024, 1, 15): ['480'],
+    DateTime.utc(2024, 1, 1): ['1'],
   };
 
   @override

--- a/dnf_cal/lib/widgets/RegisterCharacterPage/CharacterProfile.dart
+++ b/dnf_cal/lib/widgets/RegisterCharacterPage/CharacterProfile.dart
@@ -2,7 +2,7 @@ import 'dart:ffi';
 
 import 'package:dnf_cal/models/CustomColor.dart';
 import 'package:dnf_cal/models/RegisterCharacterModel.dart';
-import 'package:dnf_cal/realm/Chracter.dart';
+import 'package:dnf_cal/realm/Character.dart';
 import 'package:dnf_cal/widgets/RegisterCharacterPage/DeleteRegisterCharacterButton.dart';
 import 'package:dnf_cal/widgets/global/DnfText.dart';
 import 'package:flutter/material.dart';

--- a/dnf_cal/lib/widgets/RegisterCharacterPage/RegisterChracterEditBar.dart
+++ b/dnf_cal/lib/widgets/RegisterCharacterPage/RegisterChracterEditBar.dart
@@ -8,9 +8,18 @@ class RegisterChracterEditBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final model = Provider.of<RegisterCharacterModel>(context);
-    final characterList = model.characterList;
-    final bool isEmpty = characterList.isEmpty;
+    final String adventurerName;
+    if (context.watch<RegisterCharacterModel>().isEmpty ||
+        context.watch<RegisterCharacterModel>().characterList.isEmpty) {
+      adventurerName = "등록된 캐릭터가 없습니다.";
+    } else {
+      adventurerName = context
+              .read<RegisterCharacterModel>()
+              .characterList
+              .first
+              .adventureName ??
+          "등록된 캐릭터가 없습니다.";
+    }
     return Container(
       margin: const EdgeInsets.only(bottom: 22),
       height: 41,
@@ -32,7 +41,7 @@ class RegisterChracterEditBar extends StatelessWidget {
             child: Align(
               alignment: Alignment.centerLeft,
               child: DnfText(
-                context.watch<RegisterCharacterModel>().isEmpty ? "캐릭터를 등록해주세요" : "캐릭터 등록",
+                adventurerName,
                 fontSize: 16,
               ),
             ),

--- a/dnf_cal/lib/widgets/RegisterCharacterPage/RegisterChracterEditBar.dart
+++ b/dnf_cal/lib/widgets/RegisterCharacterPage/RegisterChracterEditBar.dart
@@ -47,10 +47,12 @@ class RegisterChracterEditBar extends StatelessWidget {
             ),
           ),
           IconButton(
-            onPressed: () {
-              Provider.of<RegisterCharacterModel>(context, listen: false)
-                  .toggleEditing();
-            },
+            // characterList가 비어있으면 edit 버튼을 눌러도 아무런 동작을 하지 않는다.
+            onPressed: context.watch<RegisterCharacterModel>().isEmpty
+                ? null
+                : () {
+                    context.read<RegisterCharacterModel>().toggleEditing();
+                  },
             icon: Icon(
               Provider.of<RegisterCharacterModel>(context).isEditing
                   ? Icons.edit_off


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #50 

## ✅ What Did You Do
- [x] 등록된 캐릭터 페이지에 실제 모험단 이름 연동
- [x] 등록된 캐릭터 페이지에서 캐릭터 삭제 후 isEdit모드 false로 변경
- [x] 달력 페이지에 실제 모험단 정보 연동
- [x] 달력 페이지에 사용될 DB class 추가
- [x] 달력 페이지의 Refresh버튼을 누르면 등록된 캐릭터들의 정보를 갱신한 뒤 총합템레벨의 평균을 기록
- [x] 기록된 날짜도 DB에 저장하여 불러오는 기능을 추가

***

## 🎸 ETC
NICE